### PR TITLE
#11 / #12 Permitir que uma escala seja posteriormente populada com voluntários disponíveis aleatoriamente

### DIFF
--- a/src/main/java/com/crescer_aprender/escala/controller/EscalaController.java
+++ b/src/main/java/com/crescer_aprender/escala/controller/EscalaController.java
@@ -135,4 +135,14 @@ public class EscalaController {
         return results.map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.noContent().build());
     }
+    @PutMapping("/popula-voluntarios/{idEscala}")
+    public ResponseEntity<Escala> populateVoluntarios(@PathVariable Long idEscala) {
+        try {
+            log.info("Populando escala previamente criada com dias a partir da lista de datas... | IdEscala ={}", idEscala);
+            return ResponseEntity.ok(escalaService.populaEscalaComVoluntarios(idEscala));
+        } catch (Exception e) {
+            log.error("Erro ao popular escala previamente criada com dias a partir da lista de datas | Error={}",e.getMessage());
+            return new ResponseEntity<>(Escala.builder().errorMessage(e.getMessage()).build(), HttpStatus.BAD_REQUEST);
+        }
+    }
 }

--- a/src/main/java/com/crescer_aprender/escala/dto/EscalaCreateRequest.java
+++ b/src/main/java/com/crescer_aprender/escala/dto/EscalaCreateRequest.java
@@ -1,5 +1,6 @@
 package com.crescer_aprender.escala.dto;
 
+import com.crescer_aprender.escala.entity.Escala;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -19,4 +20,12 @@ public class EscalaCreateRequest {
     // opcional: lista de dias com IDs de voluntarios por dia
     List<EscalaDiaRequest> dias;
     // o campo legado 'voluntarios' foi removido - favor usar 'dias[].voluntarios' ou omitir para seleção automática
+
+    public static EscalaCreateRequest of(Escala escala){
+        return EscalaCreateRequest.builder()
+                .mes(escala.getMes())
+                .ano(escala.getAno())
+                .datas(escala.getDatas())
+                .dias(EscalaDiaRequest.of(escala.getDias())).build();
+    }
 }

--- a/src/main/java/com/crescer_aprender/escala/dto/EscalaDiaRequest.java
+++ b/src/main/java/com/crescer_aprender/escala/dto/EscalaDiaRequest.java
@@ -1,11 +1,14 @@
 package com.crescer_aprender.escala.dto;
 
+import com.crescer_aprender.escala.entity.EscalaDia;
+import com.crescer_aprender.escala.entity.Voluntario;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Data
@@ -16,5 +19,19 @@ public class EscalaDiaRequest {
     LocalDate data;
     // Lista de IDs de voluntários para essa data (preferível). Se null, o service irá selecionar automaticamente baseado em disponibilidade.
     List<Long> voluntarios;
+
+    public static EscalaDiaRequest of(EscalaDia escalaDia){
+        return EscalaDiaRequest.builder()
+                .data(escalaDia.getData())
+                .voluntarios(escalaDia.getVoluntarios().stream().map(Voluntario::getId).toList())
+                .build();
+    }
+    public static List<EscalaDiaRequest> of(List<EscalaDia> escalaDias){
+         List<EscalaDiaRequest> lista = new ArrayList<>();
+        for(EscalaDia dia: escalaDias){
+            lista.add(EscalaDiaRequest.of(dia));
+        }
+        return lista;
+    }
 }
 

--- a/src/main/resources/static/swagger.yaml
+++ b/src/main/resources/static/swagger.yaml
@@ -211,6 +211,42 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /crescer-aprender/escala/popula-voluntarios/{idEscala}:
+    put:
+      tags:
+        - Escala
+      summary: Popula uma escala existente com voluntários (preenche os dias com voluntários disponíveis)
+      description: >-
+        Popula a escala identificada por `idEscala` com voluntários disponíveis para as datas já criadas na escala. O endpoint delega à lógica de serviço
+        a seleção automática dos voluntários por data.
+        
+        Observação: no controller atual o método está mapeado com `@PutMapping("/popula-voluntarios/{idEscala}")` mas o parâmetro do método usa `@RequestHeader`.
+        Isso é inconsistente com a presença de `{idEscala}` na URL — o parâmetro deveria ser `@PathVariable Long idEscala` para funcionar como esperado.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: idEscala
+          in: path
+          description: ID da escala a ser populada com voluntários
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Escala populada com sucesso
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Escala'
+        '404':
+          description: Escala não encontrada
+        '500':
+          description: Erro interno ao popular escala (ver mensagem no campo `errorMessage` do corpo quando aplicável)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /crescer-aprender/escala/buscar-por-mes-ano-voluntario:
     get:
       tags:
@@ -601,6 +637,11 @@ components:
         - voluntarios
       type: object
       properties:
+        id:
+          type: integer
+          example: 1
+          description: Id da escala
+
         mes:
           type: integer
           example: 7


### PR DESCRIPTION
Permitir que seja criada uma escala apenas com uma lista de datas ou com dias com poucos voluntários, e que posteriormente essa escala possa ser solicitada que popule o restante dela com mais voluntários aleatórios, ou que popule os dias do zero a partir das datas